### PR TITLE
Fix deck loading path and add card model tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,10 @@
-# LightWeightCardPrototiping
+# LightWeightCardPrototyping
 
 Genera cartas de forma rapida y sencilla para tus prototipos
 
 ## Descripcion
 
-Este proyecto esta basado en https://github.com/tilleraj/LightWeightMTGProxy, cerca del 80% del codigo les pertenece, sobre todo el relativo a la generacion de las cartas utilizando cairo
-
-## Descripcion
-El objetivo de este proyecto es facilitar la generacion de cartas para prototipos de juegos de mesa automatizando en la medida de lo posible las tareas de añadir una imagen asi como el texto relativo a la carta. Esta automatizacion se realiza definiendo la carta en un archivo de texto.
+Este proyecto esta basado en https://github.com/tilleraj/LightWeightMTGProxy, cerca del 80% del codigo les pertenece, sobre todo el relativo a la generacion de las cartas utilizando cairo. El objetivo de este proyecto es facilitar la generacion de cartas para prototipos de juegos de mesa automatizando en la medida de lo posible las tareas de añadir una imagen asi como el texto relativo a la carta. Esta automatizacion se realiza definiendo la carta en un archivo de texto.
 
 ## Primero Pasos
 

--- a/card_model.py
+++ b/card_model.py
@@ -9,8 +9,12 @@ class CardDeck:
         self.load(name)
 
     def load(self, name):
+        db_path = pathlib.Path(name)
 
-        with open(pathlib.Path(__file__).parent / name, encoding='utf-8') as dbFile:
+        if (not db_path.is_absolute()) and (not db_path.exists()):
+            db_path = pathlib.Path(__file__).parent / name
+
+        with open(db_path, encoding='utf-8') as dbFile:
             db = json.load(dbFile)
             self.cardDb = db
     def getDb(self):

--- a/tests/test_card_model.py
+++ b/tests/test_card_model.py
@@ -1,0 +1,70 @@
+import tempfile
+import json
+import pathlib
+import unittest
+
+from card_model import CardModel, CardDeck
+
+
+class CardModelLoadTest(unittest.TestCase):
+    def test_load_with_optional_fields(self):
+        data = {
+            "name": "Test Name",
+            "type": "Creature",
+            "subtype": "Wizard",
+            "text": "Draw a card",
+            "manaCost": "{1}{U}",
+            "power": 2,
+            "toughness": 3,
+            "image": "wizard.png",
+        }
+
+        card = CardModel()
+        card.load(data)
+
+        self.assertEqual(card.nameStr, "Test Name")
+        self.assertEqual(card.typeStr, "Creature - Wizard")
+        self.assertEqual(card.cardText, "Draw a card")
+        self.assertEqual(card.manaCost, "{1}{U}")
+        self.assertEqual(card.power, 2)
+        self.assertEqual(card.toughness, 3)
+        self.assertEqual(card.image, "wizard.png")
+
+    def test_load_without_optional_fields(self):
+        data = {
+            "name": "Vanilla",
+            "type": "Creature",
+        }
+
+        card = CardModel()
+        card.load(data)
+
+        self.assertEqual(card.nameStr, "Vanilla")
+        self.assertEqual(card.typeStr, "Creature")
+        self.assertEqual(card.cardText, "")
+        self.assertEqual(card.manaCost, "")
+        self.assertIsNone(card.power)
+        self.assertIsNone(card.toughness)
+        self.assertIsNone(card.image)
+
+
+class CardDeckLoadTest(unittest.TestCase):
+    def test_load_uses_provided_path(self):
+        cards = {
+            "Example": {
+                "name": "Example",
+                "type": "Artifact",
+            }
+        }
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            deck_path = pathlib.Path(tmp_dir) / "cards.json"
+            deck_path.write_text(json.dumps(cards), encoding="utf-8")
+
+            deck = CardDeck(str(deck_path))
+
+        self.assertIn("Example", deck.getDb())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- fix the project title in the README and consolidate the duplicated description section
- update CardDeck.load to respect the path provided by the CLI instead of assuming local JSON files
- add unit tests covering optional CardModel fields and the deck path handling

## Testing
- python -m unittest discover -s tests -p 'test_*.py'


------
https://chatgpt.com/codex/tasks/task_e_68dcf1e12678832eb328369a7541c393