### PR TITLE
Add CLI support for single-card PNG exports

### DIFF
--- a/LWCProto.py
+++ b/LWCProto.py
@@ -1,9 +1,7 @@
 #! /usr/bin/env python3
 import csv
-import json
 import os
-import pathlib
-import sys
+import re
 import numpy as np
 
 import cairo
@@ -37,6 +35,7 @@ parser.add_argument('-c', '--cards', type=extant_file, help='json file containin
 parser.add_argument('-i', '--images', help='Add images to cards', action='store_true')
 parser.add_argument('-r', '--rgb', help='Update layout card border colour with given R,G,B, only works with default layout', nargs=3, type=int)
 parser.add_argument('-l', '--layout', help='Use a different layout than default', type=extant_file, metavar="FILE")
+parser.add_argument('--single-card', help='Render each card as an individual 63x85mm PNG at 300 DPI', action='store_true')
 
 
 args = parser.parse_args()
@@ -45,10 +44,18 @@ handle_images = args.images
 modify_layout = args.rgb
 deck_file = args.deck
 cards_file = args.cards
+single_card_mode = args.single_card
 #deck_file = './example_deck.csv'
 deck_name = os.path.basename(deck_file)[:-4]
 nameList = []
 list_copy = []
+
+if handle_images or (modify_layout is not None):
+    from add_images import BaseImage
+
+if handle_images:
+    from add_images import addImage
+    from add_images import processImage
 
 with open(deck_file, encoding='utf-8') as csvFile:
     reader = csv.reader(csvFile)
@@ -67,53 +74,90 @@ if not os.path.exists('decks'):
 if not os.path.exists(os.path.join('decks',deck_name)):
     os.mkdir(os.path.join('decks',deck_name))
 
-for page_number in range(len(pageList)):
-    print(f'Page {page_number}:')
-    page = pageList[page_number]
-    surf = layout.getSurface()
-    ctx = cairo.Context(surf)
+if single_card_mode:
+    cards_output_dir = os.path.join('decks', deck_name, 'cards')
+    os.makedirs(cards_output_dir, exist_ok=True)
+    single_dpi = layout.SINGLE_CARD_DPI
 
-    for i in range(len(page)):
-        card = page[i]
-        cardPos = (i % 3, i // 3)
-        print(cardPos)
-        print(card)
-        mat = layout.getMatrix(*cardPos, surf)
-        ctx.set_matrix(mat)
+    def _slugify(value: str) -> str:
+        value = value.strip()
+        value = re.sub(r'\s+', '_', value)
+        value = re.sub(r'[^A-Za-z0-9_-]', '', value)
+        return value or 'card'
+
+    for index, card in enumerate(cardList):
+        print(f'Card {index}: {card}')
+        surf = layout.get_single_card_surface(single_dpi)
+        ctx = cairo.Context(surf)
+        ctx.set_matrix(layout.get_single_card_matrix(single_dpi))
         drawCard(card, ctx)
 
-    surf.write_to_png(f'decks/{deck_name}/{deck_name}_p{page_number}.png')
+        card_filename = f"{index:03d}_{_slugify(card.nameStr)}.png"
+        output_path = os.path.join(cards_output_dir, card_filename)
+        surf.write_to_png(output_path)
 
-    from add_images import BaseImage
-    from add_images import addImage
-    from add_images import processImage
-    from PIL import Image
+        if handle_images:
+            processImage(card, deck_name, dpi=single_dpi)
+            baseImage = BaseImage(output_path)
+            updated_image = addImage(card, baseImage, deck_name, dpi=single_dpi)
+            baseImage.update(updated_image)
+            baseImage.save(output_path)
+else:
+    for page_number in range(len(pageList)):
+        print(f'Page {page_number}:')
+        page = pageList[page_number]
+        surf = layout.getSurface()
+        ctx = cairo.Context(surf)
 
-    if (modify_layout is not None):
-        baseImage = BaseImage(f'decks/{deck_name}/{deck_name}_p{page_number}.png')
-        temp = baseImage.baseImage.convert('RGBA')
-        data = np.array(temp)
-        red, green, blue, alpha = data.T 
-        for i in range(0,63):
-            white_areas = (red == 190+i) & (blue == 190+i) & (green == 190+i)
-            data[..., :-1][white_areas.T] = (modify_layout[0], modify_layout[1], modify_layout[2])
-        baseImage.update(Image.fromarray(data))
-        baseImage.save(f'decks/{deck_name}/{deck_name}_p{page_number}.png')
-
-
-    #import pdb;pdb.set_trace()
-    if (handle_images):
-
-        if not os.path.exists(os.path.join('decks',deck_name,'images')):
-            os.mkdir(os.path.join('decks',deck_name,'images'))
-        #open the previous png to add the images
-        baseImage = BaseImage(f'decks/{deck_name}/{deck_name}_p{page_number}.png')
-        for i in range (len(page)):
+        for i in range(len(page)):
             card = page[i]
             cardPos = (i % 3, i // 3)
-            processImage(card,deck_name)
-            baseImage.update(addImage(card,baseImage,deck_name, cardPos))
-        baseImage.save(f'decks/{deck_name}/{deck_name}_p{page_number}.png')
+            print(cardPos)
+            print(card)
+            mat = layout.getMatrix(*cardPos, surf)
+            ctx.set_matrix(mat)
+            drawCard(card, ctx)
+
+        output_path = f'decks/{deck_name}/{deck_name}_p{page_number}.png'
+        surf.write_to_png(output_path)
+
+        if (modify_layout is not None):
+            from PIL import Image
+
+            baseImage = BaseImage(output_path)
+            temp = baseImage.baseImage.convert('RGBA')
+            data = np.array(temp)
+            red, green, blue, alpha = data.T
+            for i in range(0,63):
+                white_areas = (red == 190+i) & (blue == 190+i) & (green == 190+i)
+                data[..., :-1][white_areas.T] = (modify_layout[0], modify_layout[1], modify_layout[2])
+            baseImage.update(Image.fromarray(data))
+            baseImage.save(output_path)
+
+
+        #import pdb;pdb.set_trace()
+        if (handle_images):
+            page_dpi = layout.get_surface_dpi(surf)
+            baseImage = BaseImage(output_path)
+            for i in range (len(page)):
+                card = page[i]
+                cardPos = (i % 3, i // 3)
+                card_origin_mm = layout.get_card_origin_mm(cardPos)
+                image_position_mm = (
+                    card_origin_mm[0] + layout.ART_OFFSET_MM[0],
+                    card_origin_mm[1] + layout.ART_OFFSET_MM[1],
+                )
+                processImage(card,deck_name, dpi=page_dpi)
+                baseImage.update(
+                    addImage(
+                        card,
+                        baseImage,
+                        deck_name,
+                        position_mm=image_position_mm,
+                        dpi=page_dpi,
+                    )
+                )
+            baseImage.save(output_path)
 
 
 with open(f'decks/{deck_name}/{deck_name}.csv', 'w') as deck_copy:

--- a/layout.py
+++ b/layout.py
@@ -1,6 +1,10 @@
 import pathlib
 import cairo
 
+# Measurement helpers
+MM_PER_INCH = 25.4
+
+
 # All dimensions are in mm
 # Card Measurements
 nameBL = (6,8.5)
@@ -16,18 +20,69 @@ cardTextW = 51
 ptBL = (50.5,82)
 ptH = 3
 
+# Artwork measurements (relative to a single card origin)
+ART_OFFSET_MM = (5.47, 10.933333333333332)
+ART_SIZE_MM = (51.64666666666667, 38.1)
+
 #Inter-Card Measurements
 origin = (8.5,6)
 deltaX = 68
 deltaY = 90
 
+# Single card defaults
+CARD_WIDTH_MM = 63
+CARD_HEIGHT_MM = 85
+SINGLE_CARD_DPI = 300
+
+
+def mm_to_pixels(value_mm: float, dpi: float) -> int:
+    """Convert a millimetre measurement to whole pixels for a given DPI."""
+    return int(round(value_mm / MM_PER_INCH * dpi))
+
+
+def pair_mm_to_pixels(pair_mm, dpi: float):
+    """Convert a pair of millimetre measurements to pixels."""
+    return tuple(mm_to_pixels(v, dpi) for v in pair_mm)
+
+
 def getSurface() -> cairo.ImageSurface:
     return cairo.ImageSurface.create_from_png(pathlib.Path(__file__).parent / 'layout.png')
 
+
+def get_surface_dpi(surf: cairo.ImageSurface) -> float:
+    """Infer the DPI of the reference layout surface."""
+    return surf.get_width() / 8.5
+
+
 def getMatrix(x: int, y: int, surf: cairo.ImageSurface):
-    sx = surf.get_width() / 8.5 / 25.4
-    sy = surf.get_height() / 11 / 25.4
+    sx = surf.get_width() / 8.5 / MM_PER_INCH
+    sy = surf.get_height() / 11 / MM_PER_INCH
 
     x0 = (origin[0] + deltaX * x) * sx
     y0 = (origin[1] + deltaY * y) * sy
     return cairo.Matrix(x0=x0, y0=y0, xx=sx, yy=sy)
+
+
+def get_card_origin_mm(card_position):
+    """Return the absolute origin in mm for a card positioned on the 3x3 grid."""
+    return (
+        origin[0] + deltaX * card_position[0],
+        origin[1] + deltaY * card_position[1],
+    )
+
+
+def get_single_card_surface(dpi: int = SINGLE_CARD_DPI) -> cairo.ImageSurface:
+    """Create a blank single-card surface at the requested DPI."""
+    width_px = mm_to_pixels(CARD_WIDTH_MM, dpi)
+    height_px = mm_to_pixels(CARD_HEIGHT_MM, dpi)
+    surface = cairo.ImageSurface(cairo.FORMAT_ARGB32, width_px, height_px)
+    ctx = cairo.Context(surface)
+    ctx.set_source_rgb(1, 1, 1)
+    ctx.paint()
+    return surface
+
+
+def get_single_card_matrix(dpi: int = SINGLE_CARD_DPI):
+    """Return a scaling matrix to draw cards using millimetre coordinates."""
+    scale = dpi / MM_PER_INCH
+    return cairo.Matrix(xx=scale, yy=scale)


### PR DESCRIPTION
## Summary
- add a `--single-card` CLI flag to render individual 63×85 mm cards at 300 DPI with safe filenames alongside the existing page export
- expose layout helpers for millimetre-to-pixel conversion and single-card drawing surfaces/matrices
- refactor the image overlay utilities to work with millimetre coordinates in both page and single-card modes

## Testing
- python -m compileall LWCProto.py add_images.py layout.py

------
https://chatgpt.com/codex/tasks/task_e_68dcf1d70294832eabd44cdb4969bbd1