### PR TITLE
Add full-frame card rendering option with text contrast detection

### DIFF
--- a/LWCProto.py
+++ b/LWCProto.py
@@ -1,9 +1,7 @@
 #! /usr/bin/env python3
 import csv
-import json
 import os
-import pathlib
-import sys
+import re
 import numpy as np
 
 import cairo
@@ -31,92 +29,197 @@ def extant_file(x):
 
 ##### CLI args #####
 parser = argparse.ArgumentParser(description="Deck Generator for Game Designers")
-parser.add_argument('-d', '--deck', type=extant_file, help='csv file containing the deck', metavar="FILE", required=True)
+parser.add_argument('-d', '--deck', type=extant_file, help='csv file containing the deck', metavar="FILE")
 parser.add_argument('-c', '--cards', type=extant_file, help='json file containing cards description', metavar="FILE", required=True)
 
 parser.add_argument('-i', '--images', help='Add images to cards', action='store_true')
+parser.add_argument(
+    '--full-frame-images',
+    help='Scale images to cover the entire card and adjust text colour for contrast',
+    action='store_true',
+)
 parser.add_argument('-r', '--rgb', help='Update layout card border colour with given R,G,B, only works with default layout', nargs=3, type=int)
 parser.add_argument('-l', '--layout', help='Use a different layout than default', type=extant_file, metavar="FILE")
+parser.add_argument('--single-card', help='Render each card as an individual 63x85mm PNG at 300 DPI', action='store_true')
 
 
 args = parser.parse_args()
 
 handle_images = args.images
+full_frame_images = args.full_frame_images
 modify_layout = args.rgb
-deck_file = args.deck
 cards_file = args.cards
-#deck_file = './example_deck.csv'
-deck_name = os.path.basename(deck_file)[:-4]
-nameList = []
-list_copy = []
+single_card_mode = args.single_card
+deck_file = args.deck
 
-with open(deck_file, encoding='utf-8') as csvFile:
-    reader = csv.reader(csvFile)
-    list_copy.append(reader.__next__())
-    for row in reader:
-        list_copy.append(row)
-        nameList = nameList + [row[1]] * int(row[0])
+if single_card_mode and deck_file is not None:
+    parser.error('the --single-card option cannot be used together with --deck/-d')
+
+if (not single_card_mode) and deck_file is None:
+    parser.error('the --deck/-d option is required unless --single-card is specified')
+
+if full_frame_images and not handle_images:
+    parser.error('the --full-frame-images option requires --images')
 
 cards = CardDeck(cards_file)
 
-cardList = [CardModel(name,cards.getDb()) for name in nameList]
-pageList = [cardList[i:i+9] for i in range(0, len(cardList), 9)]
+nameList = []
+list_copy = []
+
+if single_card_mode:
+    deck_name = os.path.splitext(os.path.basename(cards_file))[0]
+    cardList = []
+    for entry in cards.getDb().values():
+        card = CardModel()
+        card.load(entry)
+        cardList.append(card)
+else:
+    deck_name = os.path.basename(deck_file)[:-4]
+    with open(deck_file, encoding='utf-8') as csvFile:
+        reader = csv.reader(csvFile)
+        list_copy.append(reader.__next__())
+        for row in reader:
+            list_copy.append(row)
+            nameList = nameList + [row[1]] * int(row[0])
+
+    cardList = [CardModel(name, cards.getDb()) for name in nameList]
+    pageList = [cardList[i:i+9] for i in range(0, len(cardList), 9)]
+
+if (handle_images and not full_frame_images) or (modify_layout is not None):
+    from add_images import BaseImage
+
+if handle_images and not full_frame_images:
+    from add_images import addImage
+    from add_images import processImage
+
+if handle_images and full_frame_images:
+    from add_images import load_full_frame_surface
 
 if not os.path.exists('decks'):
     os.mkdir('decks')
 if not os.path.exists(os.path.join('decks',deck_name)):
     os.mkdir(os.path.join('decks',deck_name))
 
-for page_number in range(len(pageList)):
-    print(f'Page {page_number}:')
-    page = pageList[page_number]
-    surf = layout.getSurface()
-    ctx = cairo.Context(surf)
+if single_card_mode:
+    cards_output_dir = os.path.join('decks', deck_name, 'cards')
+    os.makedirs(cards_output_dir, exist_ok=True)
+    single_dpi = layout.SINGLE_CARD_DPI
 
-    for i in range(len(page)):
-        card = page[i]
-        cardPos = (i % 3, i // 3)
-        print(cardPos)
-        print(card)
-        mat = layout.getMatrix(*cardPos, surf)
-        ctx.set_matrix(mat)
-        drawCard(card, ctx)
+    def _slugify(value: str) -> str:
+        value = value.strip()
+        value = re.sub(r'\s+', '_', value)
+        value = re.sub(r'[^A-Za-z0-9_-]', '', value)
+        return value or 'card'
 
-    surf.write_to_png(f'decks/{deck_name}/{deck_name}_p{page_number}.png')
+    for index, card in enumerate(cardList):
+        print(f'Card {index}: {card}')
+        surf = layout.get_single_card_surface(single_dpi)
+        ctx = cairo.Context(surf)
 
-    from add_images import BaseImage
-    from add_images import addImage
-    from add_images import processImage
-    from PIL import Image
+        text_color = (0.0, 0.0, 0.0)
+        if handle_images and full_frame_images:
+            full_frame_surface, computed_color = load_full_frame_surface(card, single_dpi)
+            if full_frame_surface is not None:
+                ctx.save()
+                ctx.identity_matrix()
+                ctx.set_source_surface(full_frame_surface, 0, 0)
+                ctx.paint()
+                ctx.restore()
+                if computed_color is not None:
+                    text_color = computed_color
 
-    if (modify_layout is not None):
-        baseImage = BaseImage(f'decks/{deck_name}/{deck_name}_p{page_number}.png')
-        temp = baseImage.baseImage.convert('RGBA')
-        data = np.array(temp)
-        red, green, blue, alpha = data.T 
-        for i in range(0,63):
-            white_areas = (red == 190+i) & (blue == 190+i) & (green == 190+i)
-            data[..., :-1][white_areas.T] = (modify_layout[0], modify_layout[1], modify_layout[2])
-        baseImage.update(Image.fromarray(data))
-        baseImage.save(f'decks/{deck_name}/{deck_name}_p{page_number}.png')
+        ctx.set_matrix(layout.get_single_card_matrix(single_dpi))
+        drawCard(card, ctx, text_color=text_color)
 
+        card_filename = f"{index:03d}_{_slugify(card.nameStr)}.png"
+        output_path = os.path.join(cards_output_dir, card_filename)
+        surf.write_to_png(output_path)
 
-    #import pdb;pdb.set_trace()
-    if (handle_images):
+        if handle_images and not full_frame_images:
+            processImage(card, deck_name, dpi=single_dpi)
+            baseImage = BaseImage(output_path)
+            updated_image = addImage(card, baseImage, deck_name, dpi=single_dpi)
+            baseImage.update(updated_image)
+            baseImage.save(output_path)
+else:
+    for page_number in range(len(pageList)):
+        print(f'Page {page_number}:')
+        page = pageList[page_number]
+        surf = layout.getSurface()
+        ctx = cairo.Context(surf)
 
-        if not os.path.exists(os.path.join('decks',deck_name,'images')):
-            os.mkdir(os.path.join('decks',deck_name,'images'))
-        #open the previous png to add the images
-        baseImage = BaseImage(f'decks/{deck_name}/{deck_name}_p{page_number}.png')
-        for i in range (len(page)):
+        page_dpi = layout.get_surface_dpi(surf)
+
+        for i in range(len(page)):
             card = page[i]
             cardPos = (i % 3, i // 3)
-            processImage(card,deck_name)
-            baseImage.update(addImage(card,baseImage,deck_name, cardPos))
-        baseImage.save(f'decks/{deck_name}/{deck_name}_p{page_number}.png')
+            print(cardPos)
+            print(card)
+
+            text_color = (0.0, 0.0, 0.0)
+            if handle_images and full_frame_images:
+                full_frame_surface, computed_color = load_full_frame_surface(card, page_dpi)
+                if full_frame_surface is not None:
+                    origin_px = layout.pair_mm_to_pixels(
+                        layout.get_card_origin_mm(cardPos),
+                        page_dpi,
+                    )
+                    ctx.save()
+                    ctx.identity_matrix()
+                    ctx.set_source_surface(full_frame_surface, *origin_px)
+                    ctx.paint()
+                    ctx.restore()
+                    if computed_color is not None:
+                        text_color = computed_color
+
+            mat = layout.getMatrix(*cardPos, surf)
+            ctx.set_matrix(mat)
+            drawCard(card, ctx, text_color=text_color)
+
+        output_path = f'decks/{deck_name}/{deck_name}_p{page_number}.png'
+        surf.write_to_png(output_path)
+
+        if (modify_layout is not None):
+            from PIL import Image
+
+            baseImage = BaseImage(output_path)
+            temp = baseImage.baseImage.convert('RGBA')
+            data = np.array(temp)
+            red, green, blue, alpha = data.T
+            for i in range(0,63):
+                white_areas = (red == 190+i) & (blue == 190+i) & (green == 190+i)
+                data[..., :-1][white_areas.T] = (modify_layout[0], modify_layout[1], modify_layout[2])
+            baseImage.update(Image.fromarray(data))
+            baseImage.save(output_path)
 
 
-with open(f'decks/{deck_name}/{deck_name}.csv', 'w') as deck_copy:
-    filewriter = csv.writer(deck_copy)
-    for element in list_copy:
-        filewriter.writerow(element)
+        #import pdb;pdb.set_trace()
+        if handle_images and not full_frame_images:
+            page_dpi = layout.get_surface_dpi(surf)
+            baseImage = BaseImage(output_path)
+            for i in range (len(page)):
+                card = page[i]
+                cardPos = (i % 3, i // 3)
+                card_origin_mm = layout.get_card_origin_mm(cardPos)
+                image_position_mm = (
+                    card_origin_mm[0] + layout.ART_OFFSET_MM[0],
+                    card_origin_mm[1] + layout.ART_OFFSET_MM[1],
+                )
+                processImage(card,deck_name, dpi=page_dpi)
+                baseImage.update(
+                    addImage(
+                        card,
+                        baseImage,
+                        deck_name,
+                        position_mm=image_position_mm,
+                        dpi=page_dpi,
+                    )
+                )
+            baseImage.save(output_path)
+
+
+if not single_card_mode:
+    with open(f'decks/{deck_name}/{deck_name}.csv', 'w') as deck_copy:
+        filewriter = csv.writer(deck_copy)
+        for element in list_copy:
+            filewriter.writerow(element)

--- a/add_images.py
+++ b/add_images.py
@@ -1,9 +1,24 @@
-import json
-import os
+import io
 import pathlib
-import card_model
+from functools import lru_cache
 
-from PIL import Image
+import cairo
+
+import card_model
+import layout
+
+from PIL import Image, ImageStat
+
+try:
+    _RESAMPLE = Image.Resampling.LANCZOS
+except AttributeError:
+    _RESAMPLE = Image.LANCZOS
+
+
+def _ensure_output_dir(deck: str) -> pathlib.Path:
+    path = pathlib.Path('decks') / deck / 'images'
+    path.mkdir(parents=True, exist_ok=True)
+    return path
 
 class BaseImage:
     def __init__(self, image):
@@ -24,29 +39,130 @@ class BaseImage:
         self.baseImage.save(path)
 
 
-def processImage(card: card_model.CardModel, deck):
+def _load_resized_source_image(image_name: str, size_px):
+    source_path = pathlib.Path('images') / image_name
+    try:
+        with Image.open(source_path) as original_image:
+            resized_image = original_image.resize(size_px, _RESAMPLE)
+    except (FileNotFoundError, OSError):
+        return None
+
+    return resized_image.convert('RGBA')
+
+
+def processImage(
+    card: card_model.CardModel,
+    deck: str,
+    *,
+    size_mm=layout.ART_SIZE_MM,
+    dpi: int = layout.SINGLE_CARD_DPI,
+):
     if card.image is None:
         return
-    if not os.path.exists(os.path.join('decks',deck,'images',str(card.image))):
+
+    size_px = layout.pair_mm_to_pixels(size_mm, dpi)
+    output_dir = _ensure_output_dir(deck)
+    destination = output_dir / str(card.image)
+
+    if destination.exists():
         try:
-            originalImage = Image.open('./images/' + card.image)
-            resizedImage = originalImage.resize((610,450))
-            resizedImage.save('./decks/'+ deck +'/images/' +card.image)
-        except:
-            return
+            with Image.open(destination) as existing_image:
+                if existing_image.size == size_px:
+                    return
+        except (FileNotFoundError, OSError):
+            pass
+
+    resized_image = _load_resized_source_image(str(card.image), size_px)
+    if resized_image is None:
+        return
+
+    resized_image.save(destination)
     
 
 
-def addImage (card: card_model.CardModel , base: BaseImage, deck,cardPos):
+def addImage(
+    card: card_model.CardModel,
+    base: BaseImage,
+    deck: str,
+    *,
+    position_mm=None,
+    size_mm=layout.ART_SIZE_MM,
+    dpi: int = layout.SINGLE_CARD_DPI,
+):
 
     if card.image is None:
         return base.get()
 
+    output_dir = _ensure_output_dir(deck)
+    image_path = output_dir / str(card.image)
+
     try:
-        cardImage = Image.open('./decks/'+ deck +'/images/' +str(card.image))
-        image_copy = base.copy()
-        position = ((cardPos[0]*805+165), (cardPos[1]*1060+200))
-        image_copy.paste(cardImage, position)
-        return image_copy
-    except:
-        return  base.get()
+        card_image = Image.open(image_path)
+    except (FileNotFoundError, OSError):
+        return base.get()
+
+    target_size_px = layout.pair_mm_to_pixels(size_mm, dpi)
+    if card_image.size != target_size_px:
+        card_image = card_image.resize(target_size_px, _RESAMPLE)
+
+    if card_image.mode != 'RGBA':
+        card_image = card_image.convert('RGBA')
+
+    image_copy = base.copy()
+    position_mm = position_mm or layout.ART_OFFSET_MM
+    position_px = layout.pair_mm_to_pixels(position_mm, dpi)
+
+    if 'A' in card_image.getbands():
+        mask = card_image.split()[-1]
+    else:
+        mask = None
+    image_copy.paste(card_image, position_px, mask)
+    return image_copy
+
+
+def _relative_luminance_from_mean(mean_rgb):
+    def _srgb_to_linear(value):
+        if value <= 0.04045:
+            return value / 12.92
+        return ((value + 0.055) / 1.055) ** 2.4
+
+    red, green, blue = (channel / 255.0 for channel in mean_rgb)
+    red_lin = _srgb_to_linear(red)
+    green_lin = _srgb_to_linear(green)
+    blue_lin = _srgb_to_linear(blue)
+    return 0.2126 * red_lin + 0.7152 * green_lin + 0.0722 * blue_lin
+
+
+def _best_text_color(image: Image.Image):
+    mean_rgb = ImageStat.Stat(image.convert('RGB')).mean
+    luminance = _relative_luminance_from_mean(mean_rgb)
+
+    contrast_with_white = (1.05) / (luminance + 0.05)
+    contrast_with_black = (luminance + 0.05) / 0.05
+
+    if contrast_with_white >= contrast_with_black:
+        return (1.0, 1.0, 1.0)
+    return (0.0, 0.0, 0.0)
+
+
+@lru_cache(maxsize=128)
+def _load_full_frame_surface_cached(image_name: str, dpi: int):
+    size_px = layout.pair_mm_to_pixels((layout.CARD_WIDTH_MM, layout.CARD_HEIGHT_MM), dpi)
+    resized_image = _load_resized_source_image(image_name, size_px)
+    if resized_image is None:
+        return None, None
+
+    text_color = _best_text_color(resized_image)
+
+    buffer = io.BytesIO()
+    resized_image.save(buffer, format='PNG')
+    buffer.seek(0)
+    surface = cairo.ImageSurface.create_from_png(buffer)
+    return surface, text_color
+
+
+def load_full_frame_surface(card: card_model.CardModel, dpi: int):
+    if card.image is None:
+        return None, None
+
+    return _load_full_frame_surface_cached(str(card.image), dpi)

--- a/draw_card.py
+++ b/draw_card.py
@@ -3,10 +3,10 @@ import card_model
 import layout
 
 def showWrappedText(
-    ctx: cairo.Context, 
-    text: str, 
-    top=0.0, 
-    left=0.0, 
+    ctx: cairo.Context,
+    text: str,
+    top=0.0,
+    left=0.0,
     right=None,
     lineHeight=12.0
 ):
@@ -37,7 +37,12 @@ def showWrappedText(
             currentOffset = currentOffset + lineHeight * 1.4
 
 
-def drawCard(card: card_model.CardModel , ctx: cairo.Context):
+def drawCard(
+    card: card_model.CardModel,
+    ctx: cairo.Context,
+    *,
+    text_color=(0.0, 0.0, 0.0),
+):
 
     #Set background colour
     #ctx.set_source_rgb(0.3, 0.3, 1.0)
@@ -46,20 +51,23 @@ def drawCard(card: card_model.CardModel , ctx: cairo.Context):
     ctx.select_font_face('serif')
     
     # Draw name
+    ctx.set_source_rgb(*text_color)
     ctx.set_font_size(layout.nameH)
     ctx.move_to(*layout.nameBL)
     ctx.show_text(card.nameStr)
 
     # Draw type
+    ctx.set_source_rgb(*text_color)
     ctx.set_font_size(layout.typeH)
     ctx.move_to(*layout.typeBL)
     ctx.show_text(card.typeStr)
 
     # Draw cardText
+    ctx.set_source_rgb(*text_color)
     ctx.set_font_size(layout.cardTextH)
     showWrappedText(ctx, card.cardText,
-        top=layout.cardTextBL[1], 
-        left=layout.cardTextBL[0], 
+        top=layout.cardTextBL[1],
+        left=layout.cardTextBL[0],
         right=layout.cardTextBL[0] + layout.cardTextW,
         lineHeight=layout.cardTextH
     )
@@ -67,14 +75,16 @@ def drawCard(card: card_model.CardModel , ctx: cairo.Context):
     # Draw power/toughness
     if card.power is not None:
         ptStr = str(card.power) + '/' + str(card.toughness)
+        ctx.set_source_rgb(*text_color)
         ctx.set_font_size(layout.ptH)
         ctx.move_to(*layout.ptBL)
         ctx.show_text(ptStr)
 
     # Draw Mana Cost
+    ctx.set_source_rgb(*text_color)
     ctx.set_font_size(layout.nameH)
     ctx.move_to(
-        layout.manaRight - ctx.text_extents(card.manaCost).width, 
+        layout.manaRight - ctx.text_extents(card.manaCost).width,
         layout.nameBL[1]
     )
     ctx.show_text(card.manaCost)

--- a/layout.py
+++ b/layout.py
@@ -1,6 +1,10 @@
 import pathlib
 import cairo
 
+# Measurement helpers
+MM_PER_INCH = 25.4
+
+
 # All dimensions are in mm
 # Card Measurements
 nameBL = (6,8.5)
@@ -16,18 +20,69 @@ cardTextW = 51
 ptBL = (50.5,82)
 ptH = 3
 
+# Artwork measurements (relative to a single card origin)
+ART_OFFSET_MM = (5.47, 10.933333333333332)
+ART_SIZE_MM = (51.64666666666667, 38.1)
+
 #Inter-Card Measurements
 origin = (8.5,6)
 deltaX = 68
 deltaY = 90
 
+# Single card defaults
+CARD_WIDTH_MM = 63
+CARD_HEIGHT_MM = 85
+SINGLE_CARD_DPI = 300
+
+
+def mm_to_pixels(value_mm: float, dpi: float) -> int:
+    """Convert a millimetre measurement to whole pixels for a given DPI."""
+    return int(round(value_mm / MM_PER_INCH * dpi))
+
+
+def pair_mm_to_pixels(pair_mm, dpi: float):
+    """Convert a pair of millimetre measurements to pixels."""
+    return tuple(mm_to_pixels(v, dpi) for v in pair_mm)
+
+
 def getSurface() -> cairo.ImageSurface:
     return cairo.ImageSurface.create_from_png(pathlib.Path(__file__).parent / 'layout.png')
 
+
+def get_surface_dpi(surf: cairo.ImageSurface) -> float:
+    """Infer the DPI of the reference layout surface."""
+    return surf.get_width() / 8.5
+
+
 def getMatrix(x: int, y: int, surf: cairo.ImageSurface):
-    sx = surf.get_width() / 8.5 / 25.4
-    sy = surf.get_height() / 11 / 25.4
+    sx = surf.get_width() / 8.5 / MM_PER_INCH
+    sy = surf.get_height() / 11 / MM_PER_INCH
 
     x0 = (origin[0] + deltaX * x) * sx
     y0 = (origin[1] + deltaY * y) * sy
     return cairo.Matrix(x0=x0, y0=y0, xx=sx, yy=sy)
+
+
+def get_card_origin_mm(card_position):
+    """Return the absolute origin in mm for a card positioned on the 3x3 grid."""
+    return (
+        origin[0] + deltaX * card_position[0],
+        origin[1] + deltaY * card_position[1],
+    )
+
+
+def get_single_card_surface(dpi: int = SINGLE_CARD_DPI) -> cairo.ImageSurface:
+    """Create a blank single-card surface at the requested DPI."""
+    width_px = mm_to_pixels(CARD_WIDTH_MM, dpi)
+    height_px = mm_to_pixels(CARD_HEIGHT_MM, dpi)
+    surface = cairo.ImageSurface(cairo.FORMAT_ARGB32, width_px, height_px)
+    ctx = cairo.Context(surface)
+    ctx.set_source_rgb(1, 1, 1)
+    ctx.paint()
+    return surface
+
+
+def get_single_card_matrix(dpi: int = SINGLE_CARD_DPI):
+    """Return a scaling matrix to draw cards using millimetre coordinates."""
+    scale = dpi / MM_PER_INCH
+    return cairo.Matrix(xx=scale, yy=scale)


### PR DESCRIPTION
## Summary
- add a --full-frame-images CLI flag that paints card art across the entire card and skips the legacy overlay pass
- load and cache resized full-frame art while selecting the highest-contrast text colour from the image average
- let drawCard accept a text_colour override so single-card and paginated renders use the computed contrast

## Testing
- python -m compileall LWCProto.py add_images.py layout.py draw_card.py

------
https://chatgpt.com/codex/tasks/task_e_68dcf1d70294832eabd44cdb4969bbd1