### PR TITLE
Allow configuring card text colour

### DIFF
--- a/LWCProto.py
+++ b/LWCProto.py
@@ -35,7 +35,7 @@ parser.add_argument('-c', '--cards', type=extant_file, help='json file containin
 parser.add_argument('-i', '--images', help='Add images to cards', action='store_true')
 parser.add_argument(
     '--full-frame-images',
-    help='Scale images to cover the entire card and adjust text colour for contrast',
+    help='Scale images to cover the entire card using the configured text colour',
     action='store_true',
 )
 parser.add_argument('-r', '--rgb', help='Update layout card border colour with given R,G,B, only works with default layout', nargs=3, type=int)
@@ -123,17 +123,15 @@ if single_card_mode:
         ctx.paint()
 
 
-        text_color = (0.0, 0.0, 0.0)
+        text_color = card.get_text_color_rgb()
         if handle_images and full_frame_images:
-            full_frame_surface, computed_color = load_full_frame_surface(card, single_dpi)
+            full_frame_surface = load_full_frame_surface(card, single_dpi)
             if full_frame_surface is not None:
                 ctx.save()
                 ctx.identity_matrix()
                 ctx.set_source_surface(full_frame_surface, 0, 0)
                 ctx.paint()
                 ctx.restore()
-                if computed_color is not None:
-                    text_color = computed_color
 
         ctx.reset_clip()
         ctx.set_matrix(card_matrix)
@@ -163,9 +161,9 @@ else:
             print(cardPos)
             print(card)
 
-            text_color = (0.0, 0.0, 0.0)
+            text_color = card.get_text_color_rgb()
             if handle_images and full_frame_images:
-                full_frame_surface, computed_color = load_full_frame_surface(card, page_dpi)
+                full_frame_surface = load_full_frame_surface(card, page_dpi)
                 if full_frame_surface is not None:
                     card_origin_mm = layout.get_card_origin_mm(cardPos)
                     origin_px = layout.pair_mm_to_pixels(
@@ -178,8 +176,6 @@ else:
                     ctx.set_source_surface(full_frame_surface, *origin_px)
                     ctx.paint()
                     ctx.restore()
-                    if computed_color is not None:
-                        text_color = computed_color
 
             mat = layout.getMatrix(*cardPos, surf)
             ctx.set_matrix(mat)

--- a/README.md
+++ b/README.md
@@ -51,7 +51,10 @@ El archivo de definicion de cartas es un archivo en jormato json con el siguente
             "name": "str",
             "type": "str",
             "subtype": "str",
-            "text": "str",
+            "card_text": {
+                "text": "str",
+                "colour": "#RRGGBB"
+            },
             "manaCost": "str",
             "power": int,
             "toughness": int,

--- a/add_images.py
+++ b/add_images.py
@@ -7,7 +7,7 @@ import cairo
 import card_model
 import layout
 
-from PIL import Image, ImageStat
+from PIL import Image
 
 try:
     _RESAMPLE = Image.Resampling.LANCZOS
@@ -119,50 +119,23 @@ def addImage(
     return image_copy
 
 
-def _relative_luminance_from_mean(mean_rgb):
-    def _srgb_to_linear(value):
-        if value <= 0.04045:
-            return value / 12.92
-        return ((value + 0.055) / 1.055) ** 2.4
-
-    red, green, blue = (channel / 255.0 for channel in mean_rgb)
-    red_lin = _srgb_to_linear(red)
-    green_lin = _srgb_to_linear(green)
-    blue_lin = _srgb_to_linear(blue)
-    return 0.2126 * red_lin + 0.7152 * green_lin + 0.0722 * blue_lin
-
-
-def _best_text_color(image: Image.Image):
-    mean_rgb = ImageStat.Stat(image.convert('RGB')).mean
-    luminance = _relative_luminance_from_mean(mean_rgb)
-
-    contrast_with_white = (1.05) / (luminance + 0.05)
-    contrast_with_black = (luminance + 0.05) / 0.05
-
-    if contrast_with_white >= contrast_with_black:
-        return (1.0, 1.0, 1.0)
-    return (0.0, 0.0, 0.0)
-
-
 @lru_cache(maxsize=128)
 def _load_full_frame_surface_cached(image_name: str, dpi: int):
     size_px = layout.pair_mm_to_pixels((layout.CARD_WIDTH_MM, layout.CARD_HEIGHT_MM), dpi)
     resized_image = _load_resized_source_image(image_name, size_px)
     if resized_image is None:
-        return None, None
-
-    text_color = _best_text_color(resized_image)
+        return None
 
     buffer = io.BytesIO()
     resized_image.save(buffer, format='PNG')
     buffer.seek(0)
     surface = cairo.ImageSurface.create_from_png(buffer)
-    return surface, text_color
+    return surface
 
 
 def load_full_frame_surface(card: card_model.CardModel, dpi: int):
     if card.image is None:
-        return None, None
+        return None
 
     return _load_full_frame_surface_cached(str(card.image), dpi)
 

--- a/card_model.py
+++ b/card_model.py
@@ -25,6 +25,7 @@ class CardModel:
         self.nameStr = "NAME"
         self.typeStr = "TYPE - SUBTYPE"
         self.cardText = "Some text"
+        self.cardTextColour = "#000000"
         self.manaCost = "\{W\}"
         self.power = None
         self.toughness = None
@@ -41,10 +42,17 @@ class CardModel:
         if ('subtype' in data):
             self.typeStr = self.typeStr + " - " + data['subtype']
 
-        if ('text' in data):
+        if 'card_text' in data:
+            card_text = data['card_text'] or {}
+            self.cardText = card_text.get('text', '')
+            self.cardTextColour = card_text.get('colour', '#000000') or '#000000'
+        elif 'text' in data:
+            # Backwards compatibility with older card definitions.
             self.cardText = data['text']
+            self.cardTextColour = '#000000'
         else:
             self.cardText = ""
+            self.cardTextColour = '#000000'
         
         if ('manaCost' in data):
             self.manaCost = data['manaCost']
@@ -59,3 +67,20 @@ class CardModel:
 
     def __str__(self):
         return f'{self.nameStr} - {self.manaCost} ({self.typeStr})'
+
+    def get_text_color_rgb(self):
+        colour = (self.cardTextColour or '#000000').strip()
+        if colour.startswith('#'):
+            colour = colour[1:]
+
+        if len(colour) != 6:
+            return (0.0, 0.0, 0.0)
+
+        try:
+            red = int(colour[0:2], 16) / 255.0
+            green = int(colour[2:4], 16) / 255.0
+            blue = int(colour[4:6], 16) / 255.0
+        except ValueError:
+            return (0.0, 0.0, 0.0)
+
+        return (red, green, blue)

--- a/cartas.json
+++ b/cartas.json
@@ -4,7 +4,10 @@
             "name": "nombre 1",
             "type": "Evento",
             "subtype": "Obligatorio",
-            "text": "este es un texto de prueba",
+            "card_text": {
+                "text": "este es un texto de prueba",
+                "colour": "#000000"
+            },
             "manaCost": "5/6 * {r}",
             "image": "BarcoPirata.jpg"
         },
@@ -14,7 +17,10 @@
             "name": "carta que te cagas",
             "type": "Reaccion",
             "subtype": "combate",
-            "text": "este es un texto de prueba para esta supercarta",
+            "card_text": {
+                "text": "este es un texto de prueba para esta supercarta",
+                "colour": "#FFFFFF"
+            },
             "manaCost": "2",
             "power": 60,
             "toughness": 9,

--- a/tests/test_card_model.py
+++ b/tests/test_card_model.py
@@ -12,7 +12,10 @@ class CardModelLoadTest(unittest.TestCase):
             "name": "Test Name",
             "type": "Creature",
             "subtype": "Wizard",
-            "text": "Draw a card",
+            "card_text": {
+                "text": "Draw a card",
+                "colour": "#112233",
+            },
             "manaCost": "{1}{U}",
             "power": 2,
             "toughness": 3,
@@ -25,6 +28,8 @@ class CardModelLoadTest(unittest.TestCase):
         self.assertEqual(card.nameStr, "Test Name")
         self.assertEqual(card.typeStr, "Creature - Wizard")
         self.assertEqual(card.cardText, "Draw a card")
+        self.assertEqual(card.cardTextColour, "#112233")
+        self.assertEqual(card.get_text_color_rgb(), (0x11 / 255.0, 0x22 / 255.0, 0x33 / 255.0))
         self.assertEqual(card.manaCost, "{1}{U}")
         self.assertEqual(card.power, 2)
         self.assertEqual(card.toughness, 3)
@@ -42,6 +47,8 @@ class CardModelLoadTest(unittest.TestCase):
         self.assertEqual(card.nameStr, "Vanilla")
         self.assertEqual(card.typeStr, "Creature")
         self.assertEqual(card.cardText, "")
+        self.assertEqual(card.cardTextColour, "#000000")
+        self.assertEqual(card.get_text_color_rgb(), (0.0, 0.0, 0.0))
         self.assertEqual(card.manaCost, "")
         self.assertIsNone(card.power)
         self.assertIsNone(card.toughness)


### PR DESCRIPTION
## Summary
- allow card definitions to supply text colour alongside the text content
- remove automatic contrast-based colour selection and always use the configured value
- document the updated `card_text` schema and refresh the sample card data

## Testing
- python -m pytest

------
https://chatgpt.com/codex/tasks/task_e_68e3a37225e0832e8632dd3eccc661f6