### PR TITLE
Add configurable backgrounds and command point shields

### DIFF
--- a/LWCProto.py
+++ b/LWCProto.py
@@ -1,106 +1,136 @@
 #! /usr/bin/env python3
+import argparse
 import csv
 import os
-import re
-import numpy as np
+import pathlib
+from typing import Iterable, List, Optional, Sequence, Tuple
 
 import cairo
-import argparse
-
+import numpy as np
 
 import layout
+from card_model import CardDeck, CardModel
 from draw_card import drawCard
-from card_model import CardModel
-from card_model import CardDeck
+from utils import slugify
 
 
-
-def extant_file(x):
-    """
-    'Type' for argparse - checks that file exists but does not open.
-    """
-    if not os.path.exists(x):
-        # Argparse uses the ArgumentTypeError to give a rejection message like:
-        # error: argument input: x does not exist
-        raise argparse.ArgumentTypeError("{0} does not exist".format(x))
-    return x
+def extant_file(path: str) -> str:
+    """Validate that a CLI argument points to an existing file."""
+    if not os.path.exists(path):
+        raise argparse.ArgumentTypeError(f"{path} does not exist")
+    return path
 
 
+def parse_arguments() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Deck Generator for Game Designers")
+    parser.add_argument('-d', '--deck', type=extant_file, help='csv file containing the deck', metavar="FILE")
+    parser.add_argument('-c', '--cards', type=extant_file, help='json file containing cards description', metavar="FILE", required=True)
 
-##### CLI args #####
-parser = argparse.ArgumentParser(description="Deck Generator for Game Designers")
-parser.add_argument('-d', '--deck', type=extant_file, help='csv file containing the deck', metavar="FILE")
-parser.add_argument('-c', '--cards', type=extant_file, help='json file containing cards description', metavar="FILE", required=True)
+    parser.add_argument('-i', '--images', help='Add images to cards', action='store_true')
+    parser.add_argument('-r', '--rgb', help='Update layout card border colour with given R,G,B, only works with default layout', nargs=3, type=int)
+    parser.add_argument('-l', '--layout', help='Use a different layout than default', type=extant_file, metavar="FILE")
+    parser.add_argument('--single-card', help='Render each card as an individual 63x85mm PNG at 300 DPI', action='store_true')
+    parser.add_argument('-o', '--output-dir', help='Directory where generated decks will be stored', default='decks')
 
-parser.add_argument('-i', '--images', help='Add images to cards', action='store_true')
-parser.add_argument('-r', '--rgb', help='Update layout card border colour with given R,G,B, only works with default layout', nargs=3, type=int)
-parser.add_argument('-l', '--layout', help='Use a different layout than default', type=extant_file, metavar="FILE")
-parser.add_argument('--single-card', help='Render each card as an individual 63x85mm PNG at 300 DPI', action='store_true')
+    args = parser.parse_args()
+
+    if args.single_card and args.deck is not None:
+        parser.error('the --single-card option cannot be used together with --deck/-d')
+
+    if (not args.single_card) and args.deck is None:
+        parser.error('the --deck/-d option is required unless --single-card is specified')
+
+    return args
 
 
-args = parser.parse_args()
+def chunk_cards(cards: Sequence[CardModel], chunk_size: int = 9) -> Iterable[List[CardModel]]:
+    for index in range(0, len(cards), chunk_size):
+        yield list(cards[index:index + chunk_size])
 
-handle_images = args.images
-modify_layout = args.rgb
-cards_file = args.cards
-single_card_mode = args.single_card
-deck_file = args.deck
 
-if single_card_mode and deck_file is not None:
-    parser.error('the --single-card option cannot be used together with --deck/-d')
+def _require_image_helpers(*helpers) -> None:
+    if any(helper is None for helper in helpers):
+        raise RuntimeError(
+            'Image helpers are not available. Make sure the --images flag '
+            'is used when requesting image processing.'
+        )
 
-if (not single_card_mode) and deck_file is None:
-    parser.error('the --deck/-d option is required unless --single-card is specified')
 
-cards = CardDeck(cards_file)
+def build_card_list(
+    *,
+    cards: CardDeck,
+    cards_file: str,
+    deck_file: Optional[str],
+    single_card_mode: bool,
+) -> Tuple[str, List[CardModel], Optional[List[Sequence[str]]]]:
+    card_db = cards.getDb()
 
-nameList = []
-list_copy = []
+    if single_card_mode:
+        deck_name = pathlib.Path(cards_file).stem
+        card_list: List[CardModel] = []
+        for entry in card_db.values():
+            card = CardModel()
+            card.load(entry)
+            card_list.append(card)
+        return deck_name, card_list, None
 
-if single_card_mode:
-    deck_name = os.path.splitext(os.path.basename(cards_file))[0]
-    cardList = []
-    for entry in cards.getDb().values():
-        card = CardModel()
-        card.load(entry)
-        cardList.append(card)
-else:
-    deck_name = os.path.basename(deck_file)[:-4]
-    with open(deck_file, encoding='utf-8') as csvFile:
-        reader = csv.reader(csvFile)
-        list_copy.append(reader.__next__())
+    assert deck_file is not None
+    deck_path = pathlib.Path(deck_file)
+    deck_name = deck_path.stem
+    card_list: List[CardModel] = []
+    deck_rows: List[Sequence[str]] = []
+
+    with deck_path.open(encoding='utf-8') as csv_file:
+        reader = csv.reader(csv_file)
+
+        try:
+            header = next(reader)
+        except StopIteration:
+            return deck_name, card_list, deck_rows
+
+        deck_rows.append(header)
+
         for row in reader:
-            list_copy.append(row)
-            nameList = nameList + [row[1]] * int(row[0])
+            deck_rows.append(row)
+            quantity = int(row[0])
+            name = row[1]
+            for _ in range(quantity):
+                card_list.append(CardModel(name, card_db))
 
-    cardList = [CardModel(name, cards.getDb()) for name in nameList]
-    pageList = [cardList[i:i+9] for i in range(0, len(cardList), 9)]
+    return deck_name, card_list, deck_rows
 
-if handle_images or (modify_layout is not None):
-    from add_images import BaseImage
 
-if handle_images:
-    from add_images import addImage
-    from add_images import processImage
-    from add_images import load_full_frame_surface
+def ensure_output_directories(
+    base_dir: pathlib.Path,
+    deck_name: str,
+    single_card_mode: bool,
+) -> Tuple[pathlib.Path, Optional[pathlib.Path]]:
+    deck_dir = base_dir / deck_name
+    deck_dir.mkdir(parents=True, exist_ok=True)
 
-if not os.path.exists('decks'):
-    os.mkdir('decks')
-if not os.path.exists(os.path.join('decks',deck_name)):
-    os.mkdir(os.path.join('decks',deck_name))
+    cards_output_dir: Optional[pathlib.Path] = None
+    if single_card_mode:
+        cards_output_dir = deck_dir / 'cards'
+        cards_output_dir.mkdir(parents=True, exist_ok=True)
 
-if single_card_mode:
-    cards_output_dir = os.path.join('decks', deck_name, 'cards')
-    os.makedirs(cards_output_dir, exist_ok=True)
+    return deck_dir, cards_output_dir
+
+
+def render_single_cards(
+    card_list: Sequence[CardModel],
+    *,
+    deck_name: str,
+    cards_output_dir: pathlib.Path,
+    output_root: pathlib.Path,
+    handle_images: bool,
+    base_image_cls,
+    add_image_fn,
+    process_image_fn,
+    load_full_frame_surface_fn,
+) -> None:
     single_dpi = layout.SINGLE_CARD_DPI
 
-    def _slugify(value: str) -> str:
-        value = value.strip()
-        value = re.sub(r'\s+', '_', value)
-        value = re.sub(r'[^A-Za-z0-9_-]', '', value)
-        return value or 'card'
-
-    for index, card in enumerate(cardList):
+    for index, card in enumerate(card_list):
         print(f'Card {index}: {card}')
         surf = layout.get_single_card_surface(single_dpi)
         ctx = cairo.Context(surf)
@@ -108,12 +138,13 @@ if single_card_mode:
         card_matrix = layout.get_single_card_matrix(single_dpi)
         ctx.set_matrix(card_matrix)
         layout.clip_card(ctx)
-        ctx.set_source_rgb(1, 1, 1)
-        ctx.paint()
-
+        if card.imageFullFrame:
+            ctx.set_source_rgb(1, 1, 1)
+            ctx.paint()
 
         if handle_images and card.imageFullFrame:
-            full_frame_surface = load_full_frame_surface(card, single_dpi)
+            _require_image_helpers(load_full_frame_surface_fn)
+            full_frame_surface = load_full_frame_surface_fn(card, single_dpi)
             if full_frame_surface is not None:
                 ctx.save()
                 ctx.identity_matrix()
@@ -124,39 +155,81 @@ if single_card_mode:
         ctx.reset_clip()
         ctx.set_matrix(card_matrix)
         drawCard(card, ctx)
-        card_filename = f"{index:03d}_{_slugify(card.headerText)}.png"
-        output_path = os.path.join(cards_output_dir, card_filename)
-        surf.write_to_png(output_path)
+
+        card_filename = f"{index:03d}_{slugify(card.headerText)}.png"
+        output_path = cards_output_dir / card_filename
+        surf.write_to_png(str(output_path))
 
         if handle_images and not card.imageFullFrame:
-            processImage(card, deck_name, dpi=single_dpi)
-            baseImage = BaseImage(output_path)
-            updated_image = addImage(card, baseImage, deck_name, dpi=single_dpi)
-            baseImage.update(updated_image)
-            baseImage.save(output_path)
-else:
-    for page_number in range(len(pageList)):
+            _require_image_helpers(
+                base_image_cls,
+                add_image_fn,
+                process_image_fn,
+            )
+            process_image_fn(card, deck_name, dpi=single_dpi, output_root=output_root)
+            base_image = base_image_cls(str(output_path))
+            updated_image = add_image_fn(
+                card,
+                base_image,
+                deck_name,
+                dpi=single_dpi,
+                output_root=output_root,
+            )
+            base_image.update(updated_image)
+            base_image.save(str(output_path))
+
+
+def _apply_layout_colour_modification(
+    *,
+    base_image,
+    modify_layout: Sequence[int],
+) -> None:
+    from PIL import Image
+
+    temp = base_image.baseImage.convert('RGBA')
+    data = np.array(temp)
+    red, green, blue, alpha = data.T
+    for i in range(0, 63):
+        white_areas = (red == 190 + i) & (blue == 190 + i) & (green == 190 + i)
+        data[..., :-1][white_areas.T] = (
+            modify_layout[0],
+            modify_layout[1],
+            modify_layout[2],
+        )
+    base_image.update(Image.fromarray(data))
+
+
+def render_deck_pages(
+    card_list: Sequence[CardModel],
+    *,
+    deck_name: str,
+    deck_dir: pathlib.Path,
+    output_root: pathlib.Path,
+    handle_images: bool,
+    modify_layout: Optional[Sequence[int]],
+    base_image_cls,
+    add_image_fn,
+    process_image_fn,
+    load_full_frame_surface_fn,
+) -> None:
+    for page_number, page in enumerate(chunk_cards(card_list)):
         print(f'Page {page_number}:')
-        page = pageList[page_number]
         surf = layout.getSurface()
         ctx = cairo.Context(surf)
 
         page_dpi = layout.get_surface_dpi(surf)
 
-        for i in range(len(page)):
-            card = page[i]
-            cardPos = (i % 3, i // 3)
-            print(cardPos)
+        for index, card in enumerate(page):
+            card_pos = (index % 3, index // 3)
+            print(card_pos)
             print(card)
 
             if handle_images and card.imageFullFrame:
-                full_frame_surface = load_full_frame_surface(card, page_dpi)
+                _require_image_helpers(load_full_frame_surface_fn)
+                full_frame_surface = load_full_frame_surface_fn(card, page_dpi)
                 if full_frame_surface is not None:
-                    card_origin_mm = layout.get_card_origin_mm(cardPos)
-                    origin_px = layout.pair_mm_to_pixels(
-                        card_origin_mm,
-                        page_dpi,
-                    )
+                    card_origin_mm = layout.get_card_origin_mm(card_pos)
+                    origin_px = layout.pair_mm_to_pixels(card_origin_mm, page_dpi)
                     ctx.save()
                     ctx.identity_matrix()
                     layout.clip_card_absolute(ctx, card_origin_mm, page_dpi)
@@ -164,63 +237,150 @@ else:
                     ctx.paint()
                     ctx.restore()
 
-            mat = layout.getMatrix(*cardPos, surf)
+            mat = layout.getMatrix(*card_pos, surf)
             ctx.set_matrix(mat)
             drawCard(card, ctx)
 
-        output_path = f'decks/{deck_name}/{deck_name}_p{page_number}.png'
-        surf.write_to_png(output_path)
+        output_path = deck_dir / f'{deck_name}_p{page_number}.png'
+        surf.write_to_png(str(output_path))
 
-        if (modify_layout is not None):
-            from PIL import Image
+        if modify_layout is not None:
+            if base_image_cls is None:
+                raise RuntimeError('Layout modifications require image helpers')
+            base_image = base_image_cls(str(output_path))
+            _apply_layout_colour_modification(
+                base_image=base_image,
+                modify_layout=modify_layout,
+            )
+            base_image.save(str(output_path))
 
-            baseImage = BaseImage(output_path)
-            temp = baseImage.baseImage.convert('RGBA')
-            data = np.array(temp)
-            red, green, blue, alpha = data.T
-            for i in range(0,63):
-                white_areas = (red == 190+i) & (blue == 190+i) & (green == 190+i)
-                data[..., :-1][white_areas.T] = (modify_layout[0], modify_layout[1], modify_layout[2])
-            baseImage.update(Image.fromarray(data))
-            baseImage.save(output_path)
-
-
-        #import pdb;pdb.set_trace()
         if handle_images:
-            page_dpi = layout.get_surface_dpi(surf)
             needs_partial_images = any(
                 card.image is not None and not card.imageFullFrame for card in page
             )
 
             if needs_partial_images:
-                baseImage = BaseImage(output_path)
-                for i in range(len(page)):
-                    card = page[i]
+                _require_image_helpers(
+                    base_image_cls,
+                    add_image_fn,
+                    process_image_fn,
+                )
+                base_image = base_image_cls(str(output_path))
+                for index, card in enumerate(page):
                     if card.image is None or card.imageFullFrame:
                         continue
 
-                    cardPos = (i % 3, i // 3)
-                    card_origin_mm = layout.get_card_origin_mm(cardPos)
+                    card_pos = (index % 3, index // 3)
+                    card_origin_mm = layout.get_card_origin_mm(card_pos)
                     image_position_mm = (
                         card_origin_mm[0] + layout.ART_OFFSET_MM[0],
                         card_origin_mm[1] + layout.ART_OFFSET_MM[1],
                     )
-                    processImage(card, deck_name, dpi=page_dpi)
-                    baseImage.update(
-                        addImage(
+                    process_image_fn(
+                        card,
+                        deck_name,
+                        dpi=page_dpi,
+                        output_root=output_root,
+                    )
+                    base_image.update(
+                        add_image_fn(
                             card,
-                            baseImage,
+                            base_image,
                             deck_name,
                             position_mm=image_position_mm,
                             dpi=page_dpi,
+                            output_root=output_root,
                         )
                     )
 
-                baseImage.save(output_path)
+                base_image.save(str(output_path))
 
 
-if not single_card_mode:
-    with open(f'decks/{deck_name}/{deck_name}.csv', 'w') as deck_copy:
-        filewriter = csv.writer(deck_copy)
-        for element in list_copy:
-            filewriter.writerow(element)
+def write_deck_copy(
+    deck_rows: Sequence[Sequence[str]],
+    *,
+    deck_name: str,
+    deck_dir: pathlib.Path,
+) -> None:
+    deck_copy_path = deck_dir / f'{deck_name}.csv'
+    with deck_copy_path.open('w', encoding='utf-8', newline='') as deck_copy:
+        writer = csv.writer(deck_copy)
+        for row in deck_rows:
+            writer.writerow(row)
+
+
+def main() -> None:
+    args = parse_arguments()
+
+    handle_images = args.images
+    modify_layout = args.rgb
+    cards_file = args.cards
+    single_card_mode = args.single_card
+    deck_file = args.deck
+    output_root = pathlib.Path(args.output_dir)
+    output_root.mkdir(parents=True, exist_ok=True)
+
+    cards = CardDeck(cards_file)
+    deck_name, card_list, deck_rows = build_card_list(
+        cards=cards,
+        cards_file=cards_file,
+        deck_file=deck_file,
+        single_card_mode=single_card_mode,
+    )
+
+    deck_dir, cards_output_dir = ensure_output_directories(
+        output_root,
+        deck_name,
+        single_card_mode,
+    )
+
+    base_image_cls = add_image_fn = process_image_fn = load_full_frame_surface_fn = None
+
+    if handle_images or (modify_layout is not None):
+        from add_images import BaseImage
+
+        base_image_cls = BaseImage
+
+    if handle_images:
+        from add_images import addImage, load_full_frame_surface, processImage
+
+        add_image_fn = addImage
+        process_image_fn = processImage
+        load_full_frame_surface_fn = load_full_frame_surface
+
+    if single_card_mode and cards_output_dir is not None:
+        render_single_cards(
+            card_list,
+            deck_name=deck_name,
+            cards_output_dir=cards_output_dir,
+            output_root=output_root,
+            handle_images=handle_images,
+            base_image_cls=base_image_cls,
+            add_image_fn=add_image_fn,
+            process_image_fn=process_image_fn,
+            load_full_frame_surface_fn=load_full_frame_surface_fn,
+        )
+    else:
+        render_deck_pages(
+            card_list,
+            deck_name=deck_name,
+            deck_dir=deck_dir,
+            output_root=output_root,
+            handle_images=handle_images,
+            modify_layout=modify_layout,
+            base_image_cls=base_image_cls,
+            add_image_fn=add_image_fn,
+            process_image_fn=process_image_fn,
+            load_full_frame_surface_fn=load_full_frame_surface_fn,
+        )
+
+    if (not single_card_mode) and deck_rows is not None:
+        write_deck_copy(
+            deck_rows,
+            deck_name=deck_name,
+            deck_dir=deck_dir,
+        )
+
+
+if __name__ == '__main__':
+    main()

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ En principio todo lo que se necesita para ejecutar este script es python 3.9 ins
 
 ```
 usage: LWCProto.py [-h] -d FILE -c FILE [-i] [-r RGB RGB RGB] [-l FILE]
+                   [--single-card] [-o OUTPUT_DIR]
 
 Deck Generator for Game Designers
 
@@ -38,7 +39,10 @@ optional arguments:
   -r RGB RGB RGB, --rgb RGB RGB RGB
                         Update layout card border colour with given R,G,B, only works with default layout
   -l FILE, --layout FILE (==> Not ready yet)
-                        Use a different layout than default 
+                        Use a different layout than default
+  --single-card          Render each card as an individual 63x85mm PNG at 300 DPI
+  -o OUTPUT_DIR, --output-dir OUTPUT_DIR
+                        Directory where generated decks will be stored
 ```
 ### Archivo de definicion de cartas:
 
@@ -60,7 +64,13 @@ El archivo de definicion de cartas es un archivo en jormato json con el siguente
                 "text": "str",
                 "colour": "#RRGGBB"
             },
-            "manaCost": "str",
+            "background_color": "#RRGGBB",
+            "footer": {
+                "text": "str",
+                "color": "#RRGGBB",
+                "font_style": "normal | negrita | itálica"
+            },
+            "commandPoints": int,
             "power": int,
             "toughness": int,
             "image": "str",
@@ -71,7 +81,10 @@ El archivo de definicion de cartas es un archivo en jormato json con el siguente
 ```
 El objeto `header` define el texto visible en la parte superior de la carta. El campo `color` ajusta el color del texto, mientras que los campos `banner` y `banner_color` permiten activar un recuadro de color sólido detrás del encabezado cuando sea necesario.
 El bloque `card_text` permite especificar el texto del cuerpo y el color con el que debe renderizarse. Para las imágenes puedes indicar un nombre de archivo directamente o un objeto con las claves `source` y `full_frame`. Cuando `full_frame_image` (o `full_frame` en el objeto de imagen) es `true`, la ilustración se ampliará para cubrir toda la carta; en caso contrario se mantendrá dentro del marco de arte.
-Las imagenes deben almacenarse en el directorio "images" que se encuentra en la misma carpeta que LWCProto.py, el formato de las imagenes es indiferente y su tamaño tambien estas seran redimensionadas automaticamente para adaptarse al tamaño disponible en el layout
+Puedes controlar el color de fondo del lienzo con el campo opcional `background_color`. Debe indicarse en formato hexadecimal (`#RRGGBB`) y solo se aplica cuando la carta no utiliza una imagen a pantalla completa (`full_frame_image: false`).
+El valor `commandPoints` representa los puntos de mando de la carta. Siempre se mostrará como un número dentro de un escudo con borde negro en la esquina superior derecha.
+El bloque `footer` es opcional y permite mostrar una nota en la parte inferior de la carta. Puedes personalizar el texto, su color y el estilo de fuente (`normal`, `negrita` o `itálica`). Si no se especifica `font_style`, se utilizará `normal` por defecto.
+Las imagenes deben almacenarse en el directorio "images" que se encuentra en la misma carpeta que LWCProto.py, el formato de las imagenes es indiferente y su tamaño tambien estas seran redimensionadas automaticamente para adaptarse al tamaño disponible en el layout. Puedes utilizar el argumento `--output-dir` para indicar otro directorio base donde almacenar las cartas generadas, lo que facilita mantener varios prototipos separados.
 
 ### Archivo de definicion del mazo
 

--- a/add_images.py
+++ b/add_images.py
@@ -1,6 +1,7 @@
 import io
 import pathlib
 from functools import lru_cache
+from typing import Union
 
 import cairo
 
@@ -14,8 +15,20 @@ try:
 except AttributeError:
     _RESAMPLE = Image.LANCZOS
 
-def _ensure_output_dir(deck: str) -> pathlib.Path:
-    path = pathlib.Path('decks') / deck / 'images'
+def _ensure_output_dir(deck: str, root: Union[pathlib.Path, str] = 'decks') -> pathlib.Path:
+    """Return the directory used to store processed images for a deck.
+
+    Parameters
+    ----------
+    deck:
+        Name of the deck currently being processed.
+    root:
+        Base output directory where decks are stored. Defaults to ``decks``
+        to remain backwards compatible with previous behaviour.
+    """
+
+    base_path = pathlib.Path(root)
+    path = base_path / deck / 'images'
     path.mkdir(parents=True, exist_ok=True)
     return path
 
@@ -55,12 +68,13 @@ def processImage(
     *,
     size_mm=layout.ART_SIZE_MM,
     dpi: int = layout.SINGLE_CARD_DPI,
+    output_root: Union[pathlib.Path, str] = 'decks',
 ):
     if card.image is None:
         return
 
     size_px = layout.pair_mm_to_pixels(size_mm, dpi)
-    output_dir = _ensure_output_dir(deck)
+    output_dir = _ensure_output_dir(deck, output_root)
     destination = output_dir / str(card.image)
 
     if destination.exists():
@@ -87,12 +101,13 @@ def addImage(
     position_mm=None,
     size_mm=layout.ART_SIZE_MM,
     dpi: int = layout.SINGLE_CARD_DPI,
+    output_root: Union[pathlib.Path, str] = 'decks',
 ):
 
     if card.image is None:
         return base.get()
 
-    output_dir = _ensure_output_dir(deck)
+    output_dir = _ensure_output_dir(deck, output_root)
     image_path = output_dir / str(card.image)
 
     try:

--- a/cartas.json
+++ b/cartas.json
@@ -12,7 +12,12 @@
             "text": "este es un texto de prueba",
             "colour": "#000000"
         },
-        "manaCost": "5/6 * {r}",
+        "background_color": "#F5F5F5",
+        "footer": {
+            "text": "footer carta 1",
+            "color": "#333333"
+        },
+        "commandPoints": 12,
         "image": "BarcoPirata.jpg"
     },
     "Carta2": {
@@ -28,7 +33,13 @@
             "text": "este es un texto de prueba para esta supercarta",
             "colour": "#FFFFFF"
         },
-        "manaCost": "2",
+        "background_color": "#002244",
+        "footer": {
+            "text": "footer destacado",
+            "color": "#FFD700",
+            "font_style": "negrita"
+        },
+        "commandPoints": 7,
         "power": 60,
         "toughness": 9,
         "image": "MinionNapoleonics.jpg",

--- a/draw_card.py
+++ b/draw_card.py
@@ -45,6 +45,10 @@ def drawCard(
     ctx.save()
     layout.clip_card(ctx)
 
+    if not card.imageFullFrame:
+        ctx.set_source_rgb(*card.get_background_color_rgb())
+        ctx.paint()
+
 
     ctx.select_font_face('serif')
 
@@ -98,14 +102,54 @@ def drawCard(
         ctx.move_to(*layout.ptBL)
         ctx.show_text(ptStr)
 
-    # Draw Mana Cost
-    ctx.set_source_rgb(*body_color)
-    ctx.set_font_size(layout.nameH)
-    ctx.move_to(
-        layout.manaRight - ctx.text_extents(card.manaCost).width,
-        layout.nameBL[1]
-    )
-    ctx.show_text(card.manaCost)
+    # Draw command points shield
+    ctx.save()
+    shield_x, shield_y = layout.commandPointsShieldTL
+    shield_width, shield_height = layout.commandPointsShieldSize
+    point_height = layout.commandPointsShieldPointHeight
+
+    ctx.move_to(shield_x, shield_y)
+    ctx.line_to(shield_x + shield_width, shield_y)
+    ctx.line_to(shield_x + shield_width, shield_y + shield_height * 0.65)
+    ctx.line_to(shield_x + shield_width / 2.0, shield_y + shield_height + point_height)
+    ctx.line_to(shield_x, shield_y + shield_height * 0.65)
+    ctx.close_path()
+
+    ctx.set_source_rgb(1.0, 1.0, 1.0)
+    ctx.fill_preserve()
+    ctx.set_line_width(layout.commandPointsBorderWidth)
+    ctx.set_source_rgb(0.0, 0.0, 0.0)
+    ctx.stroke()
+
+    ctx.set_font_size(layout.commandPointsFontSize)
+    text = str(card.commandPoints)
+    extents = ctx.text_extents(text)
+    center_x = shield_x + shield_width / 2.0
+    center_y = shield_y + (shield_height + point_height) / 2.0
+    text_x = center_x - (extents.x_bearing + extents.width / 2.0)
+    text_y = center_y - (extents.y_bearing + extents.height / 2.0)
+
+    ctx.set_source_rgb(0.0, 0.0, 0.0)
+    ctx.move_to(text_x, text_y)
+    ctx.show_text(text)
+    ctx.restore()
+
+    # Draw footer text
+    if card.footerText:
+        footer_slant = cairo.FONT_SLANT_NORMAL
+        footer_weight = cairo.FONT_WEIGHT_NORMAL
+
+        if card.footerFontStyle == 'italic':
+            footer_slant = cairo.FONT_SLANT_ITALIC
+        if card.footerFontStyle == 'bold':
+            footer_weight = cairo.FONT_WEIGHT_BOLD
+
+        ctx.set_source_rgb(*card.get_footer_text_color_rgb())
+        ctx.set_font_size(layout.footerH)
+        ctx.select_font_face('serif', footer_slant, footer_weight)
+        ctx.move_to(*layout.footerBL)
+        ctx.show_text(card.footerText)
+        ctx.select_font_face('serif')
 
 
     ctx.restore()

--- a/layout.py
+++ b/layout.py
@@ -11,9 +11,6 @@ MM_PER_INCH = 25.4
 # Card Measurements
 nameBL = (6,8.5)
 nameH = 2.5
-manaRight = 57
-mana0TL = (54,5.5)
-manaOS = 3.5
 typeBL = (6,52.5)
 typeH = 2
 cardTextBL = (6,58)
@@ -21,6 +18,8 @@ cardTextH = 2.2
 cardTextW = 51
 ptBL = (50.5,82)
 ptH = 3
+footerBL = (6,82)
+footerH = 1.8
 
 # Artwork measurements (relative to a single card origin)
 ART_OFFSET_MM = (5.47, 10.933333333333332)
@@ -36,6 +35,12 @@ CARD_WIDTH_MM = 63
 CARD_HEIGHT_MM = 85
 SINGLE_CARD_DPI = 300
 CARD_CORNER_RADIUS_MM = 3.0
+
+commandPointsShieldTL = (CARD_WIDTH_MM - 12.0, 4.0)
+commandPointsShieldSize = (9.0, 9.5)
+commandPointsShieldPointHeight = 3.0
+commandPointsFontSize = 4.0
+commandPointsBorderWidth = 0.5
 
 
 def mm_to_pixels(value_mm: float, dpi: float) -> int:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,7 @@
+import pathlib
+import sys
+
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tests/test_card_background.py
+++ b/tests/test_card_background.py
@@ -1,0 +1,57 @@
+import pytest
+
+try:
+    import cairo  # type: ignore
+except Exception:  # pragma: no cover - optional dependency missing
+    cairo = None
+
+from card_model import CardModel
+
+if cairo is not None:  # pragma: no branch - conditional import for optional dependency
+    import layout
+    from draw_card import drawCard
+else:  # pragma: no cover - only triggered when cairo is missing
+    layout = None
+    drawCard = None
+
+
+class TrackingCard(CardModel):
+    def __init__(self):
+        super().__init__()
+        self.background_calls = 0
+
+    def get_background_color_rgb(self):
+        self.background_calls += 1
+        return super().get_background_color_rgb()
+
+
+def _render_card(card: TrackingCard) -> TrackingCard:
+    assert cairo is not None and layout is not None and drawCard is not None
+    dpi = layout.SINGLE_CARD_DPI
+    surface = layout.get_single_card_surface(dpi)
+    ctx = cairo.Context(surface)
+    ctx.set_matrix(layout.get_single_card_matrix(dpi))
+    drawCard(card, ctx)
+    return card
+
+
+@pytest.mark.skipif(cairo is None, reason="pycairo is not available")
+def test_draw_card_requests_background_colour_when_not_full_frame():
+    card = TrackingCard()
+    card.backgroundColour = '#FF00FF'
+    card.imageFullFrame = False
+
+    rendered = _render_card(card)
+
+    assert rendered.background_calls >= 1
+
+
+@pytest.mark.skipif(cairo is None, reason="pycairo is not available")
+def test_draw_card_skips_background_when_full_frame():
+    card = TrackingCard()
+    card.backgroundColour = '#FF00FF'
+    card.imageFullFrame = True
+
+    rendered = _render_card(card)
+
+    assert rendered.background_calls == 0

--- a/tests/test_card_footer.py
+++ b/tests/test_card_footer.py
@@ -1,0 +1,56 @@
+import pytest
+
+from card_model import CardModel
+
+
+def _load_card(data):
+    card = CardModel()
+    card.load(data)
+    return card
+
+
+def test_footer_defaults_to_empty_text_and_normal_style():
+    card = _load_card({'type': 'Evento'})
+
+    assert card.footerText == ''
+    assert card.footerColour == '#000000'
+    assert card.footerFontStyle == 'normal'
+
+
+@pytest.mark.parametrize(
+    'style_value, expected',
+    [
+        ('normal', 'normal'),
+        ('negrita', 'bold'),
+        ('bold', 'bold'),
+        ('italica', 'italic'),
+        ('itálica', 'italic'),
+    ],
+)
+def test_footer_style_is_normalised(style_value, expected):
+    card = _load_card({
+        'type': 'Evento',
+        'footer': {
+            'text': 'Referencia',
+            'color': '#123456',
+            'font_style': style_value,
+        },
+    })
+
+    assert card.footerText == 'Referencia'
+    assert card.footerColour == '#123456'
+    assert card.footerFontStyle == expected
+
+
+def test_footer_accepts_alternative_style_key():
+    card = _load_card({
+        'type': 'Evento',
+        'footer': {
+            'text': 'Nota al pie',
+            'color': '#654321',
+            'tipo': 'negrita',
+        },
+    })
+
+    assert card.footerFontStyle == 'bold'
+    assert card.get_footer_text_color_rgb() == pytest.approx((0x65 / 255, 0x43 / 255, 0x21 / 255))

--- a/tests/test_card_model.py
+++ b/tests/test_card_model.py
@@ -21,11 +21,12 @@ class CardModelLoadTest(unittest.TestCase):
                 "text": "Draw a card",
                 "colour": "#112233",
             },
-            "manaCost": "{1}{U}",
+            "commandPoints": 5,
             "power": 2,
             "toughness": 3,
             "image": "wizard.png",
             "full_frame_image": True,
+            "background_color": "#123456",
         }
 
         card = CardModel()
@@ -42,11 +43,13 @@ class CardModelLoadTest(unittest.TestCase):
         self.assertEqual(card.cardText, "Draw a card")
         self.assertEqual(card.cardTextColour, "#112233")
         self.assertEqual(card.get_text_color_rgb(), (0x11 / 255.0, 0x22 / 255.0, 0x33 / 255.0))
-        self.assertEqual(card.manaCost, "{1}{U}")
+        self.assertEqual(card.commandPoints, 5)
         self.assertEqual(card.power, 2)
         self.assertEqual(card.toughness, 3)
         self.assertEqual(card.image, "wizard.png")
         self.assertTrue(card.imageFullFrame)
+        self.assertEqual(card.backgroundColour, "#123456")
+        self.assertEqual(card.get_background_color_rgb(), (0x12 / 255.0, 0x34 / 255.0, 0x56 / 255.0))
 
     def test_load_with_defaults(self):
         data = {
@@ -69,11 +72,13 @@ class CardModelLoadTest(unittest.TestCase):
         self.assertEqual(card.cardText, "")
         self.assertEqual(card.cardTextColour, "#000000")
         self.assertEqual(card.get_text_color_rgb(), (0.0, 0.0, 0.0))
-        self.assertEqual(card.manaCost, "")
+        self.assertEqual(card.commandPoints, 0)
         self.assertIsNone(card.power)
         self.assertIsNone(card.toughness)
         self.assertIsNone(card.image)
         self.assertFalse(card.imageFullFrame)
+        self.assertEqual(card.backgroundColour, "#FFFFFF")
+        self.assertEqual(card.get_background_color_rgb(), (1.0, 1.0, 1.0))
 
     def test_load_supports_image_object(self):
         data = {
@@ -92,6 +97,34 @@ class CardModelLoadTest(unittest.TestCase):
 
         self.assertEqual(card.image, "object.png")
         self.assertTrue(card.imageFullFrame)
+
+    def test_load_legacy_mana_cost_field(self):
+        data = {
+            "header": {
+                "text": "Legacy",
+            },
+            "type": "Enchantment",
+            "manaCost": "12",
+        }
+
+        card = CardModel()
+        card.load(data)
+
+        self.assertEqual(card.commandPoints, 12)
+
+    def test_load_coerces_string_command_points(self):
+        data = {
+            "header": {
+                "text": "Numbers",
+            },
+            "type": "Instant",
+            "commandPoints": " CP: 08 ",
+        }
+
+        card = CardModel()
+        card.load(data)
+
+        self.assertEqual(card.commandPoints, 8)
 
     def test_load_supports_legacy_name_field(self):
         data = {

--- a/tests/test_cli_features.py
+++ b/tests/test_cli_features.py
@@ -1,0 +1,30 @@
+import sys
+import pytest
+
+from utils import slugify
+
+try:
+    from add_images import _ensure_output_dir
+except Exception:  # pragma: no cover - optional dependency missing
+    _ensure_output_dir = None
+
+
+@pytest.mark.parametrize(
+    "value, expected",
+    [
+        ("Simple Name", "Simple_Name"),
+        ("  leading and trailing  ", "leading_and_trailing"),
+        ("special!*@#chars", "specialchars"),
+        ("", "card"),
+    ],
+)
+def test_slugify_generates_safe_names(value, expected):
+    assert slugify(value) == expected
+
+@pytest.mark.skipif(_ensure_output_dir is None, reason="Image processing dependencies are unavailable")
+def test_ensure_output_dir_uses_custom_root(tmp_path):
+    output_dir = _ensure_output_dir('demo-deck', tmp_path)
+    expected_path = tmp_path / 'demo-deck' / 'images'
+
+    assert output_dir == expected_path
+    assert output_dir.exists()

--- a/utils.py
+++ b/utils.py
@@ -1,0 +1,9 @@
+import re
+
+
+def slugify(value: str) -> str:
+    """Convert arbitrary text into a filesystem-friendly slug."""
+    value = (value or '').strip()
+    value = re.sub(r'\s+', '_', value)
+    value = re.sub(r'[^A-Za-z0-9_-]', '', value)
+    return value or 'card'


### PR DESCRIPTION
## Summary
- parse the optional `background_color` field into card models with a helper to convert it to RGB values
- paint non-full-frame renders using the configured background colour while updating the docs and sample data
- add unit tests covering both the model defaults and the rendering behaviour (skipping when cairo is unavailable)
- rename `manaCost` to `commandPoints`, mapping legacy data and documenting the new JSON schema
- render command points inside a black-bordered shield and extend the model tests to cover the new parsing rules

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68e3c63c2b3c832eafdf668c737737e1